### PR TITLE
Alter rate limiting approach to be better in multi-threaded contexts

### DIFF
--- a/src/main/java/is/swan/mcmarketapi/request/Client.java
+++ b/src/main/java/is/swan/mcmarketapi/request/Client.java
@@ -1,14 +1,17 @@
 package is.swan.mcmarketapi.request;
 
 import is.swan.mcmarketapi.Token;
+import is.swan.mcmarketapi.request.sorting.Throttler;
 import is.swan.mcmarketapi.utils.HTTPUtil;
 
 public class Client {
 
     private final Token token;
+    private final Throttler throttler;
 
     public Client(Token token) {
         this.token = token;
+        this.throttler = new Throttler();
     }
 
     public Response send(Request request) {

--- a/src/main/java/is/swan/mcmarketapi/request/Client.java
+++ b/src/main/java/is/swan/mcmarketapi/request/Client.java
@@ -2,7 +2,6 @@ package is.swan.mcmarketapi.request;
 
 import is.swan.mcmarketapi.Token;
 import is.swan.mcmarketapi.request.Request.Method;
-import is.swan.mcmarketapi.request.sorting.Throttler;
 import is.swan.mcmarketapi.utils.HTTPUtil;
 
 public class Client {

--- a/src/main/java/is/swan/mcmarketapi/request/Throttler.java
+++ b/src/main/java/is/swan/mcmarketapi/request/Throttler.java
@@ -1,4 +1,4 @@
-package is.swan.mcmarketapi.request.sorting;
+package is.swan.mcmarketapi.request;
 
 import java.util.concurrent.atomic.AtomicLong;
 

--- a/src/main/java/is/swan/mcmarketapi/request/sorting/Throttler.java
+++ b/src/main/java/is/swan/mcmarketapi/request/sorting/Throttler.java
@@ -2,27 +2,22 @@ package is.swan.mcmarketapi.request.sorting;
 
 import java.util.concurrent.atomic.AtomicLong;
 
-public class Throttler {
-	enum RequestType {
-		READ, WRITE 
-	}
-	
+import is.swan.mcmarketapi.request.Request.Method;
+
+public class Throttler {	
 	private final AtomicLong readLastRetry = new AtomicLong(0);
 	private final AtomicLong readLastRequest = new AtomicLong(System.currentTimeMillis());
 	
 	private final AtomicLong writeLastRetry = new AtomicLong(0);
 	private final AtomicLong writeLastRequest = new AtomicLong(System.currentTimeMillis());
 	
-	public long stallFor(RequestType type) {
+	public long stallFor(Method method) {
 	    long time = System.currentTimeMillis();
 	    
-	    switch (type) {
-	    	case READ:
-	    		return Throttler.stalForHelper(this.readLastRetry, this.readLastRequest, time);
-	    	case WRITE:
-	    		return Throttler.stalForHelper(this.writeLastRetry, this.writeLastRequest, time);
-	    	default:
-	    		return 0;
+	    if (method == Method.GET) {
+    		return Throttler.stalForHelper(this.readLastRetry, this.readLastRequest, time);
+	    } else {
+    		return Throttler.stalForHelper(this.writeLastRetry, this.writeLastRequest, time);
 	    }
 	}
 	

--- a/src/main/java/is/swan/mcmarketapi/request/sorting/Throttler.java
+++ b/src/main/java/is/swan/mcmarketapi/request/sorting/Throttler.java
@@ -1,0 +1,59 @@
+package is.swan.mcmarketapi.request.sorting;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+public class Throttler {
+	enum RequestType {
+		READ, WRITE 
+	}
+	
+	private final AtomicLong readLastRetry = new AtomicLong(0);
+	private final AtomicLong readLastRequest = new AtomicLong(System.currentTimeMillis());
+	
+	private final AtomicLong writeLastRetry = new AtomicLong(0);
+	private final AtomicLong writeLastRequest = new AtomicLong(System.currentTimeMillis());
+	
+	public long stallFor(RequestType type) {
+	    long time = System.currentTimeMillis();
+	    
+	    switch (type) {
+	    	case READ:
+	    		return Throttler.stalForHelper(this.readLastRetry, this.readLastRequest, time);
+	    	case WRITE:
+	    		return Throttler.stalForHelper(this.writeLastRetry, this.writeLastRequest, time);
+	    	default:
+	    		return 0;
+	    }
+	}
+	
+	private static long stalForHelper(AtomicLong aLastRetry, AtomicLong aLastRequest, long time){
+	    long lastRetry = aLastRetry.getAcquire();
+	    long lastRequest = aLastRequest.getAcquire();
+	    
+	    if (lastRetry > 0 && (time - lastRequest) < lastRetry) {
+	        return lastRetry - (time - lastRequest);
+	    } else {
+	    	return 0;
+	    }
+	}
+	
+	public void setRead(long value) {
+		readLastRetry.setRelease(value);
+		readLastRequest.setRelease(System.currentTimeMillis());
+	}
+	
+	public void setWrite(long value) {
+		writeLastRetry.setRelease(value);
+		writeLastRequest.setRelease(System.currentTimeMillis());
+	}
+	
+	public void resetRead() {
+		readLastRetry.setRelease(0);
+		readLastRequest.setRelease(System.currentTimeMillis());
+	}
+	
+	public void resetWrite() {
+		writeLastRetry.setRelease(0);
+		writeLastRequest.setRelease(System.currentTimeMillis());
+	}
+}


### PR DESCRIPTION
Hi ya,

This PR changes the approach to rate limiting to work more effectively in multi-threaded contexts. It also ensures that a request is never sent if we've previously been rate-limited and are still within the rate-limiting period/delay returned in the Retry-After header.

As discussed here: https://github.com/swanis/mcmarket-api-java-wrapper/issues/1

I've tested these changes using a local API instance and everything's working as expected.
Let me know if you'd like to see any changes. 👍 